### PR TITLE
Add optional folder to storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ s3:
   access_key_id: KEY_ID
   secret_access_key: SECRET_KEY
   bucket: database-backups
+  folder: staging # optional
   region: eu-west-1 # defaults to us-east-1
 databases:
   -

--- a/lib/stratocumulus/version.rb
+++ b/lib/stratocumulus/version.rb
@@ -1,4 +1,4 @@
 # encoding: UTF-8
 module Stratocumulus
-  VERSION = "0.0.5"
+  VERSION = "0.0.6"
 end

--- a/spec/unit/storage_spec.rb
+++ b/spec/unit/storage_spec.rb
@@ -44,13 +44,32 @@ describe Stratocumulus::Storage do
       stderr
     end
 
-    it "uploads the dump to s3" do
-      expect(files).to receive(:create).with(
-        key: "foo.sql.gz",
-        body: :database_dump,
-        multipart_chunk_size: 104_857_600,
-        public: false,
-      )
+    context "without specified folder" do
+      it "uploads the dump to s3" do
+        expect(files).to receive(:create).with(
+          key: "foo.sql.gz",
+          body: :database_dump,
+          multipart_chunk_size: 104_857_600,
+          public: false,
+        )
+      end
+    end
+
+    context "with specified folder" do
+      let(:config) do
+        base_config.merge(
+          "folder" => "folder",
+        )
+      end
+
+      it "uploads the dump to s3 in the right folder" do
+        expect(files).to receive(:create).with(
+          key: "folder/foo.sql.gz",
+          body: :database_dump,
+          multipart_chunk_size: 104_857_600,
+          public: false,
+        )
+      end
     end
 
     it "uploads to the correct s3 bucket" do


### PR DESCRIPTION
Useful when you need to backup more than one database with the same name but from a different environment.
